### PR TITLE
⬆️Update makefile to include LVGL headers in the template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(f
 # files that get distributed to every user (beyond your source archive) - add
 # whatever files you want here. This line is configured to add all header files
 # that are in the the include directory get exported
-TEMPLATE_FILES=$(INCDIR)/display $(INCDIR)/pros/llemu.*
+TEMPLATE_FILES=$(INCDIR)/display/** $(INCDIR)/pros/llemu.*
 
 .DEFAULT_GOAL=quick
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ template: clean-template library
 	$(VV)mkdir -p $(TEMPLATE_DIR)/firmware
 	$Dcp $(LIBAR) $(TEMPLATE_DIR)/firmware
 	@echo "Creating template"
-	$Dprosv5 c create-template \
-		$(TEMPLATE_DIR) $(LIBNAME) $(VERSION) \
-		$(foreach file,$(TEMPLATE_FILES) $(LIBAR),--system "$(file)") \
+	$Dpros c create-template \
+		$(TEMPLATE_DIR) $(LIBNAME) $(VERSION)  \
+		$(foreach file,$(TEMPLATE_FILES) ./firmware/$(LIBNAME).a, --system "$(file)") \
 		--target v5 --kernels $(TEMPLATE_KERNEL_SEMVER)


### PR DESCRIPTION
This PR fixes the makefile to add LVGL's headers to the template zip. Previously the template shipped with just the llemu headers and then the firmware with everything compiled. 

This was tested on a new project and confirmed to work.