### PR TITLE
🐛 LVGL 5.3: Fix touch driver

### DIFF
--- a/src/liblvgl/display.c
+++ b/src/liblvgl/display.c
@@ -26,9 +26,14 @@ static void disp_daemon(void* ign) {
 	}
 }
 
-static void vex_display_flush(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t* color) {
-	vexDisplayCopyRect(x1, y1, x2, y2, (uint32_t*)color, x2 - x1 + 1);
-	lv_flush_ready();
+static void lvgl_display_flush(int32_t x1, int32_t y1, int32_t x2, int32_t y2, const lv_color_t* color) {
+	if(screen_copy_area(x1, y1, x2, y2, (uint32_t*)color, x2 - x1 + 1) == 1) {
+		lv_flush_ready();
+	}
+	else {
+		errno = PROS_ERR;
+	}
+	
 }
 
 static bool lvgl_read_touch(lv_indev_data_t* data) {
@@ -82,15 +87,14 @@ void display_initialize(void) {
 
 	lv_disp_drv_t disp_drv;
 	lv_disp_drv_init(&disp_drv); 
-
-	disp_drv.disp_flush = vex_display_flush;
-
+	disp_drv.disp_flush = lvgl_display_flush;
 	lv_disp_drv_register(&disp_drv); 
 
 	lv_indev_drv_t touch_drv;
 	lv_indev_drv_init(&touch_drv);
 	touch_drv.type = LV_INDEV_TYPE_POINTER;
 	touch_drv.read = lvgl_read_touch;
+	lv_indev_drv_register(&touch_drv);
 
 	lv_theme_set_current(lv_theme_alien_init(40, NULL));
 	lv_obj_t* page = lv_obj_create(NULL, NULL);


### PR DESCRIPTION
### Overview:
At some point, the touch driver was broken and we didn't notice. This PR fixes that.

### Testing:
- [x] Insert printfs into the driver callback to ensure it is working properly
- [x] Run the program on the V5 to ensure that the buttons work

This has been tested and confirmed to work on actual hardware. 
