### PR TITLE
:bug: Fix whitescreen problem

### DIFF
--- a/src/liblvgl/display.c
+++ b/src/liblvgl/display.c
@@ -22,9 +22,9 @@ static void disp_daemon(void* ign) {
 	uint32_t time = millis();
 
 	while (true) {
-		lv_task_handler();
 		task_delay_until(&time, 2);
 		lv_tick_inc(2);
+		lv_task_handler();
 	}
 }
 


### PR DESCRIPTION
Half of the screen turns white during the development of Lemlib.

It looks like calling any LVGL functions before the first `lv_tick_inc` call followed by a `lv_task_handler` call seems to be the main cause of the white screen issue. It seems like any LVGL objects constructed by any lvgl function calls before the first lv_tick_inc calls can not be "registered" properly. This PR changed the order of LVGL function calls in the `disp_daemon` task.

[Bug Report on the PROS Beta Testers Server](https://discord.com/channels/1025259843763847229/1029666535553384498/1094748900239351808)