### PR TITLE
Initialize LVGL Theme

### DIFF
--- a/src/liblvgl/display.c
+++ b/src/liblvgl/display.c
@@ -117,7 +117,12 @@ void display_initialize(void) {
 		printf("Error initializing input driver\n");
 	}
 
-	// lv_theme_set_current(lv_theme_alien_init(40, NULL));
+	lv_theme_t *th = lv_theme_default_init(lv_disp_get_default(),
+									lv_palette_main(LV_PALETTE_BLUE),
+									lv_palette_main(LV_PALETTE_CYAN),
+									true,
+									LV_FONT_DEFAULT);
+	lv_disp_set_theme(lv_disp_get_default(), th);
 	lv_obj_t* page = lv_obj_create(NULL);
 	lv_obj_set_size(page, LV_HOR_RES_MAX, LV_VER_RES_MAX);
 	lv_scr_load(page);


### PR DESCRIPTION
Default theme is light, which has white background color. This PR sets the theme to a dark theme in display_initialize so that the background color is dark.