### PR TITLE
Initialize LVGL with dark theme

### DIFF
--- a/include/liblvgl/lv_conf.h
+++ b/include/liblvgl/lv_conf.h
@@ -495,6 +495,8 @@ typedef void * lv_font_user_data_t;
 #define LV_THEME_DEFAULT_FONT_SUBTITLE      &lv_font_montserrat_10
 #define LV_THEME_DEFAULT_FONT_TITLE         &lv_font_montserrat_30
 
+#define CONFIG_LV_THEME_DEFAULT_DARK 1
+
 /*=================
  *  Text settings
  *=================*/


### PR DESCRIPTION
The default background color that LVGL initializes with is white. In some cases, this can cause an obnoxious white flash when the program starts. #37 fixes this, but the PR is inactive and hasn't been merged due to an issue in their approach. This PR fixes the white flash by setting `CONFIG_LV_THEME_DEFAULT_DARK` to `1`, as @Jerrylum suggests in #37. 

This change shouldn't conflict with anything, and llemu appears the same after the change.