### PR TITLE
Enable more font sizes

### DIFF
--- a/include/liblvgl/lv_conf.h
+++ b/include/liblvgl/lv_conf.h
@@ -383,25 +383,25 @@ typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the i
  * https://fonts.google.com/specimen/Montserrat  */
 #define LV_FONT_MONTSERRAT_8     0
 #define LV_FONT_MONTSERRAT_10    1
-#define LV_FONT_MONTSERRAT_12    0
+#define LV_FONT_MONTSERRAT_12    1
 #define LV_FONT_MONTSERRAT_14    1
-#define LV_FONT_MONTSERRAT_16    0
-#define LV_FONT_MONTSERRAT_18    0
+#define LV_FONT_MONTSERRAT_16    1
+#define LV_FONT_MONTSERRAT_18    1
 #define LV_FONT_MONTSERRAT_20    1
 #define LV_FONT_MONTSERRAT_22    0
-#define LV_FONT_MONTSERRAT_24    0
+#define LV_FONT_MONTSERRAT_24    1
 #define LV_FONT_MONTSERRAT_26    0
 #define LV_FONT_MONTSERRAT_28    0
 #define LV_FONT_MONTSERRAT_30    1
 #define LV_FONT_MONTSERRAT_32    0
 #define LV_FONT_MONTSERRAT_34    0
-#define LV_FONT_MONTSERRAT_36    0
+#define LV_FONT_MONTSERRAT_36    1
 #define LV_FONT_MONTSERRAT_38    0
 #define LV_FONT_MONTSERRAT_40    1
-#define LV_FONT_MONTSERRAT_42    0
+#define LV_FONT_MONTSERRAT_42    1
 #define LV_FONT_MONTSERRAT_44    0
 #define LV_FONT_MONTSERRAT_46    0
-#define LV_FONT_MONTSERRAT_48    0
+#define LV_FONT_MONTSERRAT_48    1
 
 /* Demonstrate special features */
 #define LV_FONT_MONTSERRAT_12_SUBPX      0


### PR DESCRIPTION
### Problem
Currently, only a few sizes of LVGL's default font (Montserrat) are enabled. These sizes are: 10, 14, 20, 30, and 40. While this is a wide range, many commonly used font sizes are not included. The jump from font size 10 to 14, and 14 to 20 is also really jarring, and its hard to build a decent looking UI without some of the font sizes in between.

Since enabling these key font sizes requires a recompilation of the entire library, it forces people to either import their own fonts or add their own LVGL instance to their project. It would be nice to just remove this burden and add more options by default. 

### Proposed Changes
This PR would enable Montserrat font sizes 12, 16, 18, 24, 36, 42, and 48.