### PR TITLE
Display gif/png/jpeg using LVGL drivers from SD card

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ EXCLUDE_COLD_LIBRARIES:=
 # Set this to 1 to add additional rules to compile your project as a PROS library template
 IS_LIBRARY:=1
 LIBNAME:=liblvgl
-VERSION:=8.3.2
+VERSION:=8.3.8
 # EXCLUDE_SRC_FROM_LIB= $(SRCDIR)/unpublishedfile.c
 # this line excludes opcontrol.c and similar files
 EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(file).$(cext)) $(foreach cxxext,$(CXXEXTS),$(file).$(cxxext)))

--- a/common.mk
+++ b/common.mk
@@ -21,7 +21,7 @@ SPACE := $() $()
 COMMA := ,
 
 C_STANDARD?=gnu11
-CXX_STANDARD?=gnu++2a
+CXX_STANDARD?=gnu++20
 
 DEPDIR := .d
 $(shell mkdir -p $(DEPDIR))

--- a/common.mk
+++ b/common.mk
@@ -21,7 +21,7 @@ SPACE := $() $()
 COMMA := ,
 
 C_STANDARD?=gnu11
-CXX_STANDARD?=gnu++20
+CXX_STANDARD?=gnu++2a
 
 DEPDIR := .d
 $(shell mkdir -p $(DEPDIR))

--- a/include/liblvgl/lv_conf.h
+++ b/include/liblvgl/lv_conf.h
@@ -83,7 +83,7 @@ typedef int16_t lv_coord_t;
 #define LV_MEM_CUSTOM      0
 #if LV_MEM_CUSTOM == 0
 /* Size of the memory used by `lv_mem_alloc` in bytes (>= 2kB)*/
-#  define LV_MEM_SIZE    (32U * 1024U)
+#  define LV_MEM_SIZE    (10U * 1024U * 1024U)
 
 /* Compiler prefix for a big array declaration */
 #  define LV_MEM_ATTR
@@ -217,6 +217,15 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h" */
 typedef void * lv_fs_drv_user_data_t;
 #endif
 
+#define LV_USE_FS_STDIO 1
+#define LV_FS_STDIO_LETTER 'S'
+#define LV_FS_STDIO_PATH "/usd/"
+#define LV_FS_STDIO_CACHE_SIZE 0
+
+#define LV_USE_PNG 1
+#define LV_USE_GIF 1
+#define LV_USE_SJPG 1
+
 /*1: Add a `user_data` to drivers and objects*/
 #define LV_USE_USER_DATA        1
 
@@ -243,7 +252,7 @@ typedef void * lv_fs_drv_user_data_t;
  * With complex image decoders (e.g. PNG or JPG) caching can save the continuous open/decode of images.
  * However the opened images might consume additional RAM.
  * Set it to 0 to disable caching */
-#define LV_IMG_CACHE_DEF_SIZE       1
+#define LV_IMG_CACHE_DEF_SIZE       (8U * 1024U)
 
 /*Declare the type of the user data of image decoder (can be e.g. `void *`, `int`, `struct`)*/
 typedef void * lv_img_decoder_user_data_t;
@@ -314,7 +323,7 @@ typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the i
  *===============*/
 
 /*1: Enable the log module*/
-#define LV_USE_LOG      0
+#define LV_USE_LOG      1
 #if LV_USE_LOG
 /* How important log should be added:
  * LV_LOG_LEVEL_TRACE       A lot of logs to give detailed information
@@ -327,7 +336,7 @@ typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the i
 
 /* 1: Print the log with 'printf';
  * 0: user need to register a callback with `lv_log_register_print_cb`*/
-#  define LV_LOG_PRINTF   0
+#  define LV_LOG_PRINTF   1
 #endif  /*LV_USE_LOG*/
 
 /*=================

--- a/src/liblvgl/extra/libs/fsdrv/lv_fs_stdio.c
+++ b/src/liblvgl/extra/libs/fsdrv/lv_fs_stdio.c
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 #ifndef WIN32
-    #include <dirent.h>
+//    #include <dirent.h>
     #include <unistd.h>
 #else
     #include <windows.h>
@@ -31,7 +31,7 @@ typedef struct {
     HANDLE dir_p;
     char next_fn[MAX_PATH_LEN];
 #else
-    DIR * dir_p;
+//    DIR * dir_p;
 #endif
 } dir_handle_t;
 
@@ -84,9 +84,9 @@ void lv_fs_stdio_init(void)
     fs_drv.seek_cb = fs_seek;
     fs_drv.tell_cb = fs_tell;
 
-    fs_drv.dir_close_cb = fs_dir_close;
-    fs_drv.dir_open_cb = fs_dir_open;
-    fs_drv.dir_read_cb = fs_dir_read;
+    fs_drv.dir_close_cb = NULL;
+    fs_drv.dir_open_cb = NULL;
+    fs_drv.dir_read_cb = NULL;
 
     lv_fs_drv_register(&fs_drv);
 }
@@ -196,7 +196,7 @@ static lv_fs_res_t fs_tell(lv_fs_drv_t * drv, void * file_p, uint32_t * pos_p)
     *pos_p = ftell(file_p);
     return LV_FS_RES_OK;
 }
-
+#if 0
 /**
  * Initialize a 'DIR' or 'HANDLE' variable for directory reading
  * @param drv pointer to a driver where this function belongs
@@ -318,6 +318,7 @@ static lv_fs_res_t fs_dir_close(lv_fs_drv_t * drv, void * dir_p)
     lv_mem_free(handle);
     return LV_FS_RES_OK;
 }
+#endif
 
 #else /*LV_USE_FS_STDIO == 0*/
 

--- a/src/liblvgl/extra/libs/png/lv_png.c
+++ b/src/liblvgl/extra/libs/png/lv_png.c
@@ -147,8 +147,8 @@ static lv_res_t decoder_open(lv_img_decoder_t * decoder, lv_img_decoder_dsc_t * 
             }
 
             /*Decode the PNG image*/
-            uint32_t png_width;             /*Will be the width of the decoded image*/
-            uint32_t png_height;            /*Will be the width of the decoded image*/
+            unsigned int png_width;             /*Will be the width of the decoded image*/
+            unsigned int png_height;            /*Will be the width of the decoded image*/
 
             /*Decode the loaded image in ARGB8888 */
             error = lodepng_decode32(&img_data, &png_width, &png_height, png_data, png_data_size);
@@ -170,8 +170,8 @@ static lv_res_t decoder_open(lv_img_decoder_t * decoder, lv_img_decoder_dsc_t * 
     /*If it's a PNG file in a  C array...*/
     else if(dsc->src_type == LV_IMG_SRC_VARIABLE) {
         const lv_img_dsc_t * img_dsc = dsc->src;
-        uint32_t png_width;             /*No used, just required by he decoder*/
-        uint32_t png_height;            /*No used, just required by he decoder*/
+        unsigned int png_width;             /*No used, just required by he decoder*/
+        unsigned int png_height;            /*No used, just required by he decoder*/
 
         /*Decode the image in ARGB8888 */
         error = lodepng_decode32(&img_data, &png_width, &png_height, img_dsc->data, img_dsc->data_size);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,12 +28,6 @@ void initialize() {
 	pros::lcd::set_text(1, "Hello PROS User!");
 
 	pros::lcd::register_btn1_cb(on_center_button);
-	// For PNG/JPG/JPEG:
-	lv_obj_t * img= lv_img_create(lv_scr_act());
-  	lv_img_set_src(img, "S:cat.jpg");
-	// For GIF:
-	lv_obj_t * gif = lv_gif_create(lv_scr_act());
-	lv_gif_set_src(gif, "S:pbj.gif");
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "main.h"
+#include "liblvgl/lvgl.h"
 
 /**
  * A callback function for LLEMU's center button.
@@ -23,10 +24,19 @@ void on_center_button() {
  * to keep execution time for this mode under a few seconds.
  */
 void initialize() {
+	/*
 	pros::lcd::initialize();
 	pros::lcd::set_text(1, "Hello PROS User!");
 
 	pros::lcd::register_btn1_cb(on_center_button);
+	*/
+/*
+	lv_obj_t * img= lv_img_create(lv_scr_act());
+  	lv_img_set_src(img, "S:cat.jpg");
+	printf("image printed");
+	*/
+	lv_obj_t * gif = lv_gif_create(lv_scr_act());
+	lv_gif_set_src(gif, "S:pbj.gif");
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,17 +24,14 @@ void on_center_button() {
  * to keep execution time for this mode under a few seconds.
  */
 void initialize() {
-	/*
 	pros::lcd::initialize();
 	pros::lcd::set_text(1, "Hello PROS User!");
 
 	pros::lcd::register_btn1_cb(on_center_button);
-	*/
-/*
+	// For PNG/JPG/JPEG:
 	lv_obj_t * img= lv_img_create(lv_scr_act());
   	lv_img_set_src(img, "S:cat.jpg");
-	printf("image printed");
-	*/
+	// For GIF:
 	lv_obj_t * gif = lv_gif_create(lv_scr_act());
 	lv_gif_set_src(gif, "S:pbj.gif");
 }


### PR DESCRIPTION
Uses internal LVGL drivers to display to screen. Directory functions in filesystem driver are currently null. Uses /usd/ path, so the path only needs the filesystem specifier then file name

Examples: 
GIF:
```
lv_obj_t * gif = lv_gif_create(lv_scr_act());
lv_gif_set_src(gif, "S:pbj.gif");
```
PNG:
```
lv_obj_t * img= lv_img_create(lv_scr_act());
lv_img_set_src(img, "S:sandwich.png");
```
JPEG:
```
lv_obj_t * img= lv_img_create(lv_scr_act());
lv_img_set_src(img, "S:cat.jpg");
```