### PR TITLE
LVGL Update Script

### DIFF
--- a/update.py
+++ b/update.py
@@ -9,102 +9,110 @@ import re
 
 # Files that should persist in the template directory
 keep_files = [
-	"include/liblvgl/lv_conf.h",
-	"include/liblvgl/lv_conf.old.h", 
-	"include/liblvgl/llemu.h",
-	"include/liblvgl/llemu.hpp",
-	"include/liblvgl/font/lv_font.h",
-	"src/liblvgl/display.c",
-	"src/liblvgl/llemu.c",
-	"src/liblvgl/llemu.cpp",
-	"src/liblvgl/lv_fonts/pros_font_dejavu_mono_10.c",
-	"src/liblvgl/lv_fonts/pros_font_dejavu_mono_18.c",
-	"src/liblvgl/lv_fonts/pros_font_dejavu_mono_30.c",
-	"src/liblvgl/lv_fonts/pros_font_dejavu_mono_40.c",
+    "include/liblvgl/lv_conf.h",
+    "include/liblvgl/lv_conf.old.h",
+    "include/liblvgl/llemu.h",
+    "include/liblvgl/llemu.hpp",
+    "include/liblvgl/font/lv_font.h",
+    "src/liblvgl/display.c",
+    "src/liblvgl/llemu.c",
+    "src/liblvgl/llemu.cpp",
+    "src/liblvgl/lv_fonts/pros_font_dejavu_mono_10.c",
+    "src/liblvgl/lv_fonts/pros_font_dejavu_mono_18.c",
+    "src/liblvgl/lv_fonts/pros_font_dejavu_mono_30.c",
+    "src/liblvgl/lv_fonts/pros_font_dejavu_mono_40.c",
 ]
 
-# TODO: Version checker
-# TODO: Better output
 
 def clone(branch):
-	if type(branch) != str:
-		raise Exception("Parameter 'branch' should be a string!")
-	
-	sub_proc = subprocess.Popen(f"git clone -b {branch} https://github.com/lvgl/lvgl.git --recursive", 
-							 	stdout=subprocess.PIPE, 
-							 	stderr=subprocess.PIPE, 
-							 	shell=True)
-	sub_proc.wait()
+    if type(branch) != str:
+        raise Exception("Parameter 'branch' should be a string!")
+
+    sub_proc = subprocess.Popen(
+        f"git clone -b {branch} https://github.com/lvgl/lvgl.git --recursive",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
+    )
+    sub_proc.wait()
+
 
 def clean_template_dir():
-	if not os.path.exists("temp"): 
-		os.mkdir("temp")
-	
-	for file in keep_files:
-		output = f"temp/{file}"
-		os.makedirs(os.path.dirname(output), exist_ok=True)
-		shutil.copy(file, output)
+    if not os.path.exists("temp"):
+        os.mkdir("temp")
 
-	shutil.rmtree("include/liblvgl")
-	shutil.rmtree("src/liblvgl")
+    for file in keep_files:
+        output = f"temp/{file}"
+        os.makedirs(os.path.dirname(output), exist_ok=True)
+        shutil.copy(file, output)
 
-	for file in keep_files:
-		os.makedirs(os.path.dirname(file), exist_ok=True)
-		shutil.copy(f"temp/{file}", file)
-	
-	shutil.rmtree("temp")
+    shutil.rmtree("include/liblvgl")
+    shutil.rmtree("src/liblvgl")
+
+    for file in keep_files:
+        os.makedirs(os.path.dirname(file), exist_ok=True)
+        shutil.copy(f"temp/{file}", file)
+
+    shutil.rmtree("temp")
+
 
 def copy_lvgl_files():
-	lvgl_src = Path("lvgl/src").resolve()
-	header_files = glob.glob("**/*.h", recursive=True, root_dir=lvgl_src)
-	source_files = glob.glob("**/*.c", recursive=True, root_dir=lvgl_src)
+    lvgl_src = Path("lvgl/src").resolve()
+    header_files = glob.glob("**/*.h", recursive=True, root_dir=lvgl_src)
+    source_files = glob.glob("**/*.c", recursive=True, root_dir=lvgl_src)
 
-	for file in header_files:
-		os.makedirs(os.path.dirname(f"include/liblvgl/{file}"), exist_ok=True)
-		shutil.move(f"lvgl/src/{file}", f"include/liblvgl/{file}")
-		fix_includes(Path(f"include/liblvgl/{file}").resolve())
+    for file in header_files:
+        os.makedirs(os.path.dirname(f"include/liblvgl/{file}"), exist_ok=True)
+        shutil.move(f"lvgl/src/{file}", f"include/liblvgl/{file}")
+        fix_includes(Path(f"include/liblvgl/{file}").resolve())
 
-	for file in source_files:
-		os.makedirs(os.path.dirname(f"src/liblvgl/{file}"), exist_ok=True)
-		shutil.move(f"lvgl/src/{file}", f"src/liblvgl/{file}")
-		fix_includes(Path(f"src/liblvgl/{file}").resolve())
-	
-	os.remove("include/liblvgl/lvgl.h")
-	shutil.move("lvgl/lvgl.h", "include/liblvgl/lvgl.h")
-	fix_includes("include/liblvgl/lvgl.h")
+    for file in source_files:
+        os.makedirs(os.path.dirname(f"src/liblvgl/{file}"), exist_ok=True)
+        shutil.move(f"lvgl/src/{file}", f"src/liblvgl/{file}")
+        fix_includes(Path(f"src/liblvgl/{file}").resolve())
 
-	shutil.rmtree("lvgl/")
+    os.remove("include/liblvgl/lvgl.h")
+    shutil.move("lvgl/lvgl.h", "include/liblvgl/lvgl.h")
+    fix_includes("include/liblvgl/lvgl.h")
+
+    shutil.rmtree("lvgl/")
+
 
 def fix_includes(file_path):
-	def resolve_include_path(match):
-		file_dir = Path(file_path).parent
-		include_path = match.group(1)
-		resolved_path = file_dir.joinpath(include_path).resolve()
+    def resolve_include_path(match):
+        file_dir = Path(file_path).parent
+        include_path = match.group(1)
+        resolved_path = file_dir.joinpath(include_path).resolve()
 
-		source_dir = Path.cwd().joinpath("src/")
-		include_dir = Path.cwd().joinpath("include/")
+        source_dir = Path.cwd().joinpath("src/")
+        include_dir = Path.cwd().joinpath("include/")
 
-		# FIXME: Some files break this, aren't relative to either path. How to handle this?
-		if resolved_path.is_relative_to(source_dir):
-			relative_path = resolved_path.relative_to(source_dir)
-		elif resolved_path.is_relative_to(include_dir):
-			relative_path = resolved_path.relative_to(include_dir)
-		else:
-			relative_path = f"WEIRD PATH: {include_path}"
+        # FIXME: Some files break this, aren't relative to either path. How to handle this?
+        if resolved_path.is_relative_to(source_dir):
+            relative_path = resolved_path.relative_to(source_dir)
+        elif resolved_path.is_relative_to(include_dir):
+            relative_path = resolved_path.relative_to(include_dir)
+        else:
+            relative_path = f"WEIRD PATH: {include_path}"
 
-		return f'#include "{relative_path}"'
-	
+        return f'#include "{relative_path}"'
 
-	with open(file_path) as file:
-		data = file.read()
-		data = re.sub(r"#include \"((?:\.\./)+.*\.h)\"", resolve_include_path, data)
-		data = re.sub(r"#include \"(src/|lvgl/)", "#include \"liblvgl/", data)
-		data = re.sub(r"(?<!LV_LVGL_H_INCLUDE_SIMPLE\n)(?:^[ \t]*(#include \"lvgl.h\")$)", "#include \"liblvgl/lvgl.h\"", data, flags=re.M)
-	
-	with open(file_path, "w") as file:
-		file.write(data)
+    with open(file_path) as file:
+        data = file.read()
+        data = re.sub(r"#include \"((?:\.\./)+.*\.h)\"", resolve_include_path, data)
+        data = re.sub(r"#include \"(src/|lvgl/)", '#include "liblvgl/', data)
+        data = re.sub(
+            r"(?<!LV_LVGL_H_INCLUDE_SIMPLE\n)(?:^[ \t]*(#include \"lvgl.h\")$)",
+            '#include "liblvgl/lvgl.h"',
+            data,
+            flags=re.M,
+        )
+
+    with open(file_path, "w") as file:
+        file.write(data)
+
 
 if __name__ == "__main__":
-	clone("release/v8.4")
-	clean_template_dir()
-	copy_lvgl_files()
+    clone("release/v8.4")
+    clean_template_dir()
+    copy_lvgl_files()

--- a/update.py
+++ b/update.py
@@ -18,16 +18,15 @@ keep_files = [
 	"src/liblvgl/llemu.cpp",
 ]
 
-def clone(repo, branch):
-	if type(repo) != str:
-		raise Exception("Parameter 'repo' should be a string!")
+def clone(branch):
 	if type(branch) != str:
 		raise Exception("Parameter 'branch' should be a string!")
 	
-	sub_proc = subprocess.Popen(f"git clone -b {branch} {repo} --recursive", 
+	sub_proc = subprocess.Popen(f"git clone -b {branch} https://github.com/lvgl/lvgl.git --recursive", 
 							 	stdout=subprocess.PIPE, 
 							 	stderr=subprocess.PIPE, 
 							 	shell=True)
+	sub_proc.wait()
 
 def clean_template_dir():
 	if not os.path.exists("temp"): 
@@ -61,6 +60,6 @@ def copy_lvgl_files():
 		shutil.move(f"lvgl/src/{file}", f"src/liblvgl/{file}")
 
 if __name__ == "__main__":
-	#clone("https://github.com/lvgl/lvgl.git", "master")
+	clone("master")
 	copy_lvgl_files()
 	#clone("https://github.com/lvgl/lvgl.git", sys.argv[1])

--- a/update.py
+++ b/update.py
@@ -43,7 +43,7 @@ def warn(message):
 
 
 def error(message):
-    print(f"{ERR_COLOR}ERROR:{MSG_COLOR}{message}{NO_COLOR}")
+    print(f"{ERR_COLOR}ERROR: {MSG_COLOR}{message}{NO_COLOR}")
 
 
 def step(message):

--- a/update.py
+++ b/update.py
@@ -23,13 +23,13 @@ lvgl_repo = "https://github.com/lvgl/lvgl.git"
 
 ############################# END OF CONFIGURATION #############################
 
-import subprocess
-from pathlib import Path
 from argparse import ArgumentParser
 from os import chmod
-import stat
-import shutil
+from pathlib import Path
 import re
+import shutil
+import stat
+import subprocess
 
 WARN_COLOR = "\033[1;33m"
 ERR_COLOR = "\033[0;31m"

--- a/update.py
+++ b/update.py
@@ -16,6 +16,10 @@ keep_files = [
 	"src/liblvgl/display.c",
 	"src/liblvgl/llemu.c",
 	"src/liblvgl/llemu.cpp",
+	"src/liblvgl/lv_fonts/pros_font_dejavu_mono_10.c",
+	"src/liblvgl/lv_fonts/pros_font_dejavu_mono_18.c",
+	"src/liblvgl/lv_fonts/pros_font_dejavu_mono_30.c",
+	"src/liblvgl/lv_fonts/pros_font_dejavu_mono_40.c",
 ]
 
 # TODO: Version checker

--- a/update.py
+++ b/update.py
@@ -73,7 +73,7 @@ def copy_lvgl_files():
     shutil.copy("lvgl/lvgl.h", "include/liblvgl/lvgl.h")
     fix_includes("include/liblvgl/lvgl.h")
 
-    shutil.rmtree("lvgl/")
+    shutil.rmtree("lvgl/", ignore_errors=True)
 
 
 def fix_includes(file_path):

--- a/update.py
+++ b/update.py
@@ -2,7 +2,6 @@
 
 import subprocess
 from pathlib import Path
-from time import sleep
 from argparse import ArgumentParser
 import shutil
 import re

--- a/update.py
+++ b/update.py
@@ -28,13 +28,31 @@ import stat
 import shutil
 import re
 
+WARN_COLOR = "\033[1;33m"
+ERR_COLOR = "\033[0;31m"
+STEP_COLOR = "\033[1;37m"
+MSG_COLOR = "\033[0;37m"
+NO_COLOR = "\033[0m"
+
+
+def warn(message):
+    print(f"{WARN_COLOR}WARNING: {MSG_COLOR}{message}{NO_COLOR}")
+
+
+def error(message):
+    print(f"{ERR_COLOR}ERROR:{MSG_COLOR}{message}{NO_COLOR}")
+
+
+def step(message):
+    print(f"{STEP_COLOR}- {message} -{NO_COLOR}")
+
 
 def onexc_chmod(retry, path, err):
     chmod(path, stat.S_IWUSR)
     try:
         retry(path)
     except Exception as err:
-        print(f"[Error]: Failed to rmtree with exception: {err}")
+        error(f"Failed to rmtree with exception: {err}")
 
 
 def clone(branch):
@@ -47,7 +65,7 @@ def clone(branch):
         shell=True,
     )
     if sub_proc.wait() != 0:
-        print("[Error]: Clone failed, exiting...")
+        error("Clone failed, exiting...")
         exit(1)
 
 
@@ -120,8 +138,8 @@ def fix_includes(file_path):
         elif resolved_path.is_relative_to(include_dir):
             relative_path = resolved_path.relative_to(include_dir)
         else:
-            print(
-                f'[Warning]: File "{file}" includes file "{include_path}",'
+            warn(
+                f'File "{file}" includes file "{include_path}",'
                 + " which is outside of the src or include directory."
                 + " Manual editing may be required."
             )
@@ -169,7 +187,7 @@ def main():
     args = parser.parse_args()
 
     if not args.yes:
-        print(
+        warn(
             "Local changes may be deleted by this script."
             + " If you have made any changes, you should exit this script to"
             + " stash or commit them now."
@@ -182,13 +200,13 @@ def main():
 
         input("Press any key to continue...")
 
-    print("--- Clone LVGL ---")
+    step("Clone LVGL")
     clone(args.branch)
 
-    print("--- Remove old liblvgl files ---")
+    step("Remove old liblvgl files")
     clean_template_dir()
 
-    print("--- Copy updated files ---")
+    step("Copy updated files")
     copy_lvgl_files()
 
 

--- a/update.py
+++ b/update.py
@@ -178,12 +178,6 @@ def main():
         action="store_true",
         help="ignore initial warning",
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="show extra information",
-    )
     args = parser.parse_args()
 
     if not args.yes:

--- a/update.py
+++ b/update.py
@@ -2,7 +2,7 @@
 
 ################################ CONFIGURATION ################################
 
-# Files that should persist in the template directory
+# Files that should persist in the template directory (as POSIX-formatted paths)
 keep_files = [
     "include/liblvgl/lv_conf.h",
     "include/liblvgl/lv_conf.old.h",

--- a/update.py
+++ b/update.py
@@ -80,20 +80,24 @@ def copy_lvgl_files():
 
 def fix_includes(file_path):
     def resolve_include_path(match):
-        file_dir = Path(file_path).parent
+        file = Path(file_path)
         include_path = match.group(1)
-        resolved_path = file_dir.joinpath(include_path).resolve()
+        resolved_path = file.parent.joinpath(include_path).resolve()
 
         source_dir = Path.cwd().joinpath("src/")
         include_dir = Path.cwd().joinpath("include/")
 
-        # FIXME: Some files break this, aren't relative to either path. How to handle this?
         if resolved_path.is_relative_to(source_dir):
             relative_path = resolved_path.relative_to(source_dir)
         elif resolved_path.is_relative_to(include_dir):
             relative_path = resolved_path.relative_to(include_dir)
         else:
-            relative_path = f"WEIRD PATH: {include_path}"
+            print(
+                f'[Warning]: File "{file}" includes file "{include_path}",'
+                + "which is outside of the src or include directory."
+                + "Manual editing may be required."
+            )
+            relative_path = include_path
 
         return f'#include "{relative_path}"'
 

--- a/update.py
+++ b/update.py
@@ -79,7 +79,7 @@ def clean_template_dir():
     print("Copying whitelisted files to temp directory...")
     for file in keep_files:
         if not Path(file).exists():
-            print(f'[Warning]: Whitelisted file "{file}" does not exist')
+            warn(f'Whitelisted file "{file}" does not exist')
             keep_files.remove(file)
             continue
         output = Path(f"temp/{file}")

--- a/update.py
+++ b/update.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import glob
+import sys
+import subprocess
+import os
+import shutil
+
+# Files that should persist in the template directory
+keep_files = [
+	"include/liblvgl/lv_conf.h",
+	"include/liblvgl/lv_conf.old.h", 
+	"include/liblvgl/llemu.h",
+	"include/liblvgl/llemu.hpp",
+	"src/liblvgl/display.c",
+	"src/liblvgl/llemu.c",
+	"src/liblvgl/llemu.cpp",
+]
+
+def clone(repo, branch):
+	if type(repo) != str:
+		raise Exception("Parameter 'repo' should be a string!")
+	if type(branch) != str:
+		raise Exception("Parameter 'branch' should be a string!")
+	
+	sub_proc = subprocess.Popen(f"git clone {repo} --recursive", 
+							 	stdout=subprocess.PIPE, 
+							 	stderr=subprocess.PIPE, 
+							 	shell=True)
+	sub_proc.communicate("cd lvgl")
+	sub_proc.communicate(f"git checkout {branch}")
+
+def clean_template_dir():
+	if not os.path.exists("temp"): 
+		os.mkdir("temp")
+	
+	for file in keep_files:
+		output = f"temp/{file}"
+		os.makedirs(os.path.dirname(output), exist_ok=True)
+		shutil.copy(file, output)
+
+	shutil.rmtree("include/liblvgl")
+	shutil.rmtree("src/liblvgl")
+
+	for file in keep_files:
+		os.makedirs(os.path.dirname(file), exist_ok=True)
+		shutil.copy(f"temp/{file}", file)
+
+if __name__ == "__main__":
+	clean_template_dir()
+	#clone("https://github.com/lvgl/lvgl.git", sys.argv[1])

--- a/update.py
+++ b/update.py
@@ -34,30 +34,37 @@ def clone(branch):
 
 
 def clean_template_dir():
+    print("Creating temp directory...")
     Path("temp").mkdir(exist_ok=True)
 
+    print("Copying whitelisted files to temp directory...")
     for file in keep_files:
         output = Path(f"temp/{file}")
         output.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(file, output)
 
+    print("Removing template files...")
     shutil.rmtree("include/liblvgl")
     shutil.rmtree("src/liblvgl")
 
+    print("Copying whitelisted files back to template directories...")
     for file in keep_files:
         output = Path(file)
         output.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(f"temp/{file}", file)
 
+    print("Removing temp directory...")
     shutil.rmtree("temp")
 
 
 def copy_lvgl_files():
+    print("Getting lvgl files...")
     lvgl_src = Path("lvgl/src").resolve()
     header_files = list(lvgl_src.rglob("**/*.h"))
     source_files = list(lvgl_src.rglob("**/*.c"))
     files = header_files + source_files
 
+    print("Copying header and source files to respective directories...")
     for file in files:
         if file in header_files:
             new_loc = Path(f"include/liblvgl/{file.relative_to(lvgl_src)}")
@@ -68,10 +75,12 @@ def copy_lvgl_files():
         shutil.copy(file, new_loc)
         fix_includes(new_loc)
 
+    print("Swapping the proxy lvgl.h file with the full file...")
     Path("include/liblvgl/lvgl.h").unlink(missing_ok=True)
     shutil.copy("lvgl/lvgl.h", "include/liblvgl/lvgl.h")
     fix_includes("include/liblvgl/lvgl.h")
 
+    print("Attempting to remove lvgl source...")
     shutil.rmtree("lvgl/", ignore_errors=True)
 
 
@@ -151,13 +160,13 @@ def main():
 
         input("Press any key to continue...")
 
-    print("Cloning LVGL...")
+    print("--- Clone LVGL ---")
     clone(args.branch)
 
-    print("Removing old liblvgl files...")
+    print("--- Remove old liblvgl files ---")
     clean_template_dir()
 
-    print("Copying updated files from LVGL...")
+    print("--- Copy updated files ---")
     copy_lvgl_files()
 
 

--- a/update.py
+++ b/update.py
@@ -4,6 +4,7 @@ import glob
 import sys
 import subprocess
 import os
+from pathlib import Path
 import shutil
 
 # Files that should persist in the template directory
@@ -23,12 +24,10 @@ def clone(repo, branch):
 	if type(branch) != str:
 		raise Exception("Parameter 'branch' should be a string!")
 	
-	sub_proc = subprocess.Popen(f"git clone {repo} --recursive", 
+	sub_proc = subprocess.Popen(f"git clone -b {branch} {repo} --recursive", 
 							 	stdout=subprocess.PIPE, 
 							 	stderr=subprocess.PIPE, 
 							 	shell=True)
-	sub_proc.communicate("cd lvgl")
-	sub_proc.communicate(f"git checkout {branch}")
 
 def clean_template_dir():
 	if not os.path.exists("temp"): 
@@ -48,6 +47,20 @@ def clean_template_dir():
 	
 	shutil.rmtree("temp")
 
+def copy_lvgl_files():
+	lvgl_src = Path("lvgl/src").resolve()
+	header_files = glob.glob("**/*.h", recursive=True, root_dir=lvgl_src)
+	source_files = glob.glob("**/*.c", recursive=True, root_dir=lvgl_src)
+
+	for file in header_files:
+		os.makedirs(os.path.dirname(f"include/liblvgl/{file}"), exist_ok=True)
+		shutil.move(f"lvgl/src/{file}", f"include/liblvgl/{file}")
+
+	for file in source_files:
+		os.makedirs(os.path.dirname(f"src/liblvgl/{file}"), exist_ok=True)
+		shutil.move(f"lvgl/src/{file}", f"src/liblvgl/{file}")
+
 if __name__ == "__main__":
-	clean_template_dir()
+	#clone("https://github.com/lvgl/lvgl.git", "master")
+	copy_lvgl_files()
 	#clone("https://github.com/lvgl/lvgl.git", sys.argv[1])

--- a/update.py
+++ b/update.py
@@ -18,6 +18,9 @@ keep_files = [
     "src/liblvgl/lv_fonts/pros_font_dejavu_mono_40.c",
 ]
 
+# URI to LVGL's source
+lvgl_repo = "https://github.com/lvgl/lvgl.git"
+
 ############################# END OF CONFIGURATION #############################
 
 import subprocess
@@ -61,7 +64,7 @@ def clone(branch):
         shutil.rmtree("lvgl/", onexc=onexc_chmod)
 
     sub_proc = subprocess.Popen(
-        f"git clone -b {branch} https://github.com/lvgl/lvgl.git --recursive",
+        f"git clone -b {branch} {lvgl_repo} --recursive",
         shell=True,
     )
     if sub_proc.wait() != 0:

--- a/update.py
+++ b/update.py
@@ -45,6 +45,8 @@ def clean_template_dir():
 	for file in keep_files:
 		os.makedirs(os.path.dirname(file), exist_ok=True)
 		shutil.copy(f"temp/{file}", file)
+	
+	shutil.rmtree("temp")
 
 if __name__ == "__main__":
 	clean_template_dir()

--- a/update.py
+++ b/update.py
@@ -114,6 +114,10 @@ def copy_lvgl_files():
         elif file in source_files:
             new_loc = Path(f"src/liblvgl/{file.relative_to(lvgl_src)}")
 
+        if new_loc.as_posix() in keep_files:
+            print(f"Skipped overwriting whitelisted file at {new_loc}")
+            continue
+
         new_loc.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(file, new_loc)
         fix_includes(new_loc)

--- a/update.py
+++ b/update.py
@@ -23,7 +23,6 @@ keep_files = [
 ]
 
 # TODO: Version checker
-# TODO: Includes fixer
 # TODO: Better output
 
 def clone(branch):

--- a/update.py
+++ b/update.py
@@ -18,6 +18,10 @@ keep_files = [
 	"src/liblvgl/llemu.cpp",
 ]
 
+# TODO: Version checker
+# TODO: Includes fixer
+# TODO: Better output
+
 def clone(branch):
 	if type(branch) != str:
 		raise Exception("Parameter 'branch' should be a string!")

--- a/update.py
+++ b/update.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import glob
-import sys
 import subprocess
 import os
 from pathlib import Path

--- a/update.py
+++ b/update.py
@@ -93,8 +93,8 @@ def fix_includes(file_path):
         else:
             print(
                 f'[Warning]: File "{file}" includes file "{include_path}",'
-                + "which is outside of the src or include directory."
-                + "Manual editing may be required."
+                + " which is outside of the src or include directory."
+                + " Manual editing may be required."
             )
             relative_path = include_path
 

--- a/update.py
+++ b/update.py
@@ -27,8 +27,6 @@ keep_files = [
 def clone(branch):
     sub_proc = subprocess.Popen(
         f"git clone -b {branch} https://github.com/lvgl/lvgl.git --recursive",
-        stdout=subprocess.STDOUT,
-        stderr=subprocess.STDOUT,
         shell=True,
     )
     sub_proc.wait()
@@ -99,7 +97,7 @@ def fix_includes(file_path):
 
         return f'#include "{relative_path}"'
 
-    with open(file_path) as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         data = file.read()
         data = re.sub(r"#include \"((?:\.\./)+.*\.h)\"", resolve_include_path, data)
         data = re.sub(r"#include \"(src/|lvgl/)", '#include "liblvgl/', data)
@@ -110,7 +108,7 @@ def fix_includes(file_path):
             flags=re.M,
         )
 
-    with open(file_path, "w") as file:
+    with open(file_path, "w", encoding="utf-8") as file:
         file.write(data)
 
 

--- a/update.py
+++ b/update.py
@@ -30,7 +30,9 @@ def clone(branch):
         f"git clone -b {branch} https://github.com/lvgl/lvgl.git --recursive",
         shell=True,
     )
-    sub_proc.wait()
+    if sub_proc.wait() != 0:
+        print("[Error]: Clone failed, exiting...")
+        exit(1)
 
 
 def clean_template_dir():

--- a/update.py
+++ b/update.py
@@ -13,6 +13,7 @@ keep_files = [
 	"include/liblvgl/lv_conf.old.h", 
 	"include/liblvgl/llemu.h",
 	"include/liblvgl/llemu.hpp",
+	"include/liblvgl/font/lv_font.h",
 	"src/liblvgl/display.c",
 	"src/liblvgl/llemu.c",
 	"src/liblvgl/llemu.cpp",
@@ -85,17 +86,20 @@ def fix_includes(file_path):
 
 		# FIXME: Some files break this, aren't relative to either path. How to handle this?
 		if resolved_path.is_relative_to(source_dir):
-			relative_path = resolved_path.relative_to()
+			relative_path = resolved_path.relative_to(source_dir)
 		elif resolved_path.is_relative_to(include_dir):
 			relative_path = resolved_path.relative_to(include_dir)
+		else:
+			relative_path = f"WEIRD PATH: {include_path}"
 
 		return f'#include "{relative_path}"'
 	
 
 	with open(file_path) as file:
 		data = file.read()
-		data = re.sub(r"#include \"((?:\.\./)+.*\.h)", resolve_include_path, data)
+		data = re.sub(r"#include \"((?:\.\./)+.*\.h)\"", resolve_include_path, data)
 		data = re.sub(r"#include \"(src/|lvgl/)", "#include \"liblvgl/", data)
+		data = re.sub(r"(?<!LV_LVGL_H_INCLUDE_SIMPLE\n)(?:^[ \t]*(#include \"lvgl.h\")$)", "#include \"liblvgl/lvgl.h\"", data, flags=re.M)
 	
 	with open(file_path, "w") as file:
 		file.write(data)

--- a/update.py
+++ b/update.py
@@ -69,13 +69,16 @@ def copy_lvgl_files():
 		shutil.move(f"lvgl/src/{file}", f"src/liblvgl/{file}")
 		fix_includes(Path(f"src/liblvgl/{file}").resolve())
 	
+	os.remove("include/liblvgl/lvgl.h")
+	shutil.move("lvgl/lvgl.h", "include/liblvgl/lvgl.h")
+	fix_includes("include/liblvgl/lvgl.h")
+
 	shutil.rmtree("lvgl/")
 
 def fix_includes(file_path):
 	with open(file_path) as file:
 		data = file.read()
-		data.replace("#include \"lvgl/", "#include \"liblvgl/")
-		data = re.sub(r"#include \"(\.\./)+", "#include \"liblvgl/", data)
+		data = re.sub(r"#include \"(src/|lvgl/|(\.\./)+)", "#include \"liblvgl/", data)
 	
 	with open(file_path, "w") as file:
 		file.write(data)

--- a/update.py
+++ b/update.py
@@ -76,9 +76,14 @@ def copy_lvgl_files():
 	shutil.rmtree("lvgl/")
 
 def fix_includes(file_path):
+	# FIXME: This callback brokey
+	def resolve_include_path(match):
+		return str(Path(os.path.dirname(file_path)).joinpath(match).resolve())
+
 	with open(file_path) as file:
 		data = file.read()
-		data = re.sub(r"#include \"(src/|lvgl/|(\.\./)+)", "#include \"liblvgl/", data)
+		data = re.sub(r"#include \"((?:\.\./)+.*\.h)", resolve_include_path, data)
+		data = re.sub(r"#include \"(src/|lvgl/)", "#include \"liblvgl/", data)
 	
 	with open(file_path, "w") as file:
 		file.write(data)

--- a/update.py
+++ b/update.py
@@ -58,8 +58,10 @@ def copy_lvgl_files():
 	for file in source_files:
 		os.makedirs(os.path.dirname(f"src/liblvgl/{file}"), exist_ok=True)
 		shutil.move(f"lvgl/src/{file}", f"src/liblvgl/{file}")
+	
+	shutil.rmtree("lvgl/")
 
 if __name__ == "__main__":
 	clone("master")
+	clean_template_dir()
 	copy_lvgl_files()
-	#clone("https://github.com/lvgl/lvgl.git", sys.argv[1])

--- a/update.py
+++ b/update.py
@@ -56,23 +56,22 @@ def clean_template_dir():
 
 def copy_lvgl_files():
     lvgl_src = Path("lvgl/src").resolve()
-    header_files = lvgl_src.rglob("**/*.h")
-    source_files = lvgl_src.rglob("**/*.c")
+    header_files = list(lvgl_src.rglob("**/*.h"))
+    source_files = list(lvgl_src.rglob("**/*.c"))
+    files = header_files + source_files
 
-    for file in header_files:
-        new_loc = Path(f"include/liblvgl/{file.relative_to(lvgl_src)}")
-        new_loc.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(file, new_loc)
-        fix_includes(new_loc)
+    for file in files:
+        if file in header_files:
+            new_loc = Path(f"include/liblvgl/{file.relative_to(lvgl_src)}")
+        elif file in source_files:
+            new_loc = Path(f"src/liblvgl/{file.relative_to(lvgl_src)}")
 
-    for file in source_files:
-        new_loc = Path(f"src/liblvgl/{file.relative_to(lvgl_src)}")
         new_loc.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(file, new_loc)
+        shutil.copy(file, new_loc)
         fix_includes(new_loc)
 
     Path("include/liblvgl/lvgl.h").unlink(missing_ok=True)
-    shutil.move("lvgl/lvgl.h", "include/liblvgl/lvgl.h")
+    shutil.copy("lvgl/lvgl.h", "include/liblvgl/lvgl.h")
     fix_includes("include/liblvgl/lvgl.h")
 
     shutil.rmtree("lvgl/")

--- a/update.py
+++ b/update.py
@@ -76,9 +76,22 @@ def copy_lvgl_files():
 	shutil.rmtree("lvgl/")
 
 def fix_includes(file_path):
-	# FIXME: This callback brokey
 	def resolve_include_path(match):
-		return str(Path(os.path.dirname(file_path)).joinpath(match).resolve())
+		file_dir = Path(file_path).parent
+		include_path = match.group(1)
+		resolved_path = file_dir.joinpath(include_path).resolve()
+
+		source_dir = Path.cwd().joinpath("src/")
+		include_dir = Path.cwd().joinpath("include/")
+
+		# FIXME: Some files break this, aren't relative to either path. How to handle this?
+		if resolved_path.is_relative_to(source_dir):
+			relative_path = resolved_path.relative_to()
+		elif resolved_path.is_relative_to(include_dir):
+			relative_path = resolved_path.relative_to(include_dir)
+
+		return f'#include "{relative_path}"'
+	
 
 	with open(file_path) as file:
 		data = file.read()

--- a/update.py
+++ b/update.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python3
 
-import subprocess
-from pathlib import Path
-from argparse import ArgumentParser
-from os import chmod
-import stat
-import shutil
-import re
+################################ CONFIGURATION ################################
 
 # Files that should persist in the template directory
 keep_files = [
@@ -23,6 +17,16 @@ keep_files = [
     "src/liblvgl/lv_fonts/pros_font_dejavu_mono_30.c",
     "src/liblvgl/lv_fonts/pros_font_dejavu_mono_40.c",
 ]
+
+############################# END OF CONFIGURATION #############################
+
+import subprocess
+from pathlib import Path
+from argparse import ArgumentParser
+from os import chmod
+import stat
+import shutil
+import re
 
 
 def onexc_chmod(retry, path, err):

--- a/update.py
+++ b/update.py
@@ -210,6 +210,8 @@ def main():
     step("Copy updated files")
     copy_lvgl_files()
 
+    step("Successfully updated")
+
 
 if __name__ == "__main__":
     main()

--- a/update.py
+++ b/update.py
@@ -23,6 +23,8 @@ keep_files = [
     "src/liblvgl/lv_fonts/pros_font_dejavu_mono_40.c",
 ]
 
+# FIXME: rmtree-ing the lvgl git repository throws a permission error on windows
+
 
 def clone(branch):
     sub_proc = subprocess.Popen(

--- a/update.py
+++ b/update.py
@@ -41,6 +41,10 @@ def clean_template_dir():
 
     print("Copying whitelisted files to temp directory...")
     for file in keep_files:
+        if not Path(file).exists():
+            print(f'[Warning]: Whitelisted file "{file}" does not exist')
+            keep_files.remove(file)
+            continue
         output = Path(f"temp/{file}")
         output.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(file, output)

--- a/update.py
+++ b/update.py
@@ -115,7 +115,7 @@ def copy_lvgl_files():
             new_loc = Path(f"src/liblvgl/{file.relative_to(lvgl_src)}")
 
         if new_loc.as_posix() in keep_files:
-            print(f"Skipped overwriting whitelisted file at {new_loc}")
+            print(f'Skipped overwriting whitelisted file "{new_loc}"')
             continue
 
         new_loc.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This pull request adds a Python script that updates liblvgl to a specified upstream version of LVGL. This resolves #34.

As per the initial issue, upon invocation of the script it will:
- Clone the LVGL source
- Copy header files and source files into `include/liblvgl` and `src/liblvgl` respectively
- Fix the include directives to match the PROS project structure

The script is a very basic CLI that accepts an upstream branch argument to update from; it is intended to be run manually since some issues may arise from updating that cannot be fixed automatically. Python was chosen for the language since it is easy to work with, and other PROS projects like the CLI use Python.

### Differences
Some behaviors of this script are different than what was described in the initial issue:
- LVGL is not kept as a submodule in the repository, instead it temporarily clones LVGL to copy files.
- The script does not check if liblvgl is up to date. It is trivial to compare versions manually, but a lot of extra work is needed to do this automatically.
- The script does not necessarily fix the font issue described in the issue. Instead it features an ignore list, where files specified are not removed or changed by the update.
- The LVGL version to update from is chosen manually for more control. This allows updating from one minor/patch version to another, instead of only jumping to the latest version (which may have significant breaking changes).

### Also worth noting
- The script sticks to using standard Python libraries so it's as portable as possible
- It has been tested for Windows and macOS on Python 3.12
- It is formatted with the Black formatter

I'm happy to make any changes if necessary!