### PR TITLE
🚨 silence enum bitwise operation warning

### DIFF
--- a/include/liblvgl/core/lv_obj_style.h
+++ b/include/liblvgl/core/lv_obj_style.h
@@ -91,7 +91,10 @@ void lv_obj_remove_style(struct _lv_obj_t * obj, lv_style_t * style, lv_style_se
  */
 static inline void lv_obj_remove_style_all(struct _lv_obj_t * obj)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
     lv_obj_remove_style(obj, NULL, LV_PART_ANY | LV_STATE_ANY);
+#pragma GCC diagnostic pop
 }
 
 /**


### PR DESCRIPTION
#### Overview
Silence the "bitwise operation between different enumeration types '<unnamed enum>' and '<unnamed enum>' is deprecated" warning generated by the `lv_obj_style.h` file

#### Motivation
This warning is unhelpful, and every file which includes `main.h` will generate this warning. It is driving me insane

#### Implementation
Use GCC diagnostic pragmas to silence a specific function in `lv_obj_style.h`. This ensures that the warning will still be generated for other bits of code
```c++
static inline void lv_obj_remove_style_all(struct _lv_obj_t* obj) {
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
    lv_obj_remove_style(obj, NULL, LV_PART_ANY | LV_STATE_ANY);
#pragma GCC diagnostic pop
}
```
And yes, the pragmas not being indented is intentional, as it's standard practice.

#### Testing
I tested on my machine, it works fine. The warning is not generated for this specific function but still is for other functions